### PR TITLE
fix: add link to xpring reference implementation

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The source code for each spec is in [src/spec](https://github.com/payid-org/rfcs
 
 Known implementations of PayID and PayID Discovery:
 
-- JavaScript: TBD.
+- [TypeScript](https://github.com/payid-org/payid)
 - Java: TBD.
 - Swift: TBD.
 


### PR DESCRIPTION
## High Level Overview of Change

Just noticed it said "TBD" on the JS implementation so I changed it to TS and linked https://github.com/payid-org/payid.

### Type of Change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [x] Documentation Updates
- [ ] Release