### PR TITLE
Remove trailing whitespace from RFCs

### DIFF
--- a/src/spec/payid-discovery.md
+++ b/src/spec/payid-discovery.md
@@ -51,7 +51,7 @@ informative:
    to discover information about a 'payid' URI using standard HTTP methods.
 
    The primary use-case of this protocol is to define how to transform a
-   PayID URI into a URL that can be used with other protocols.   
+   PayID URI into a URL that can be used with other protocols.
 
 --- middle
 
@@ -135,7 +135,7 @@ informative:
        "subject" : "payid:bob$receiver.example.com",
        "links" :
        [
-         {  
+         {
            "rel": "https://payid.org/ns/payid-uri-template/1.0",
            "template": "https://receiver.example.com/users/{acctpart}"
          }
@@ -202,46 +202,46 @@ informative:
   which is defined in more detail below. The following is a visual
   representation of the protocol flow:
 
-                        +--------------------------+                    
-                        |        PayID URI         |                    
-                        |    alice$example.com     |                    
-                        +--------------------------+                    
-                                      |                                 
-                                      v                                 
-                        +--------------------------+                    
-                        |         Assemble         |                    
-                        |   PayID Discovery URL    |                    
-                        +--------------------------+                    
-                                      |                                 
-                                      v                                 
-                        +--------------------------+                    
-                        |          Query           |                    
-                  +-----|   PayID Discovery URL    |-----+              
-                  |     +--------------------------+     |              
-                  |                                  Success            
-                  |                                      |              
-                  |                                      v              
+                        +--------------------------+
+                        |        PayID URI         |
+                        |    alice$example.com     |
+                        +--------------------------+
+                                      |
+                                      v
+                        +--------------------------+
+                        |         Assemble         |
+                        |   PayID Discovery URL    |
+                        +--------------------------+
+                                      |
+                                      v
+                        +--------------------------+
+                        |          Query           |
+                  +-----|   PayID Discovery URL    |-----+
+                  |     +--------------------------+     |
+                  |                                  Success
+                  |                                      |
+                  |                                      v
                   |                        +---------------------------+
               Failure                      |   Parse PayID Metadata    |
                   |                        +---------------------------+
-                  |                                      |              
-                  |                                      v              
+                  |                                      |
+                  |                                      v
                   |                        +---------------------------+
                   |                        | Select PayID URI Template |
                   |                        +---------------------------+
-                  |                                      |              
-                  v                                      v              
+                  |                                      |
+                  v                                      v
     +--------------------------+           +---------------------------+
     |  Manual PayID Discovery  |           |    Assemble PayID URL     |
     +--------------------------+           +---------------------------+
-                  |                                      |              
-                  +---------------------+----------------+              
-                                        |                               
-                                        v                               
-                          +---------------------------+                 
-                          |         PayID URL         |                 
-                          | https://example.com/alice |                 
-                          +---------------------------+                 
+                  |                                      |
+                  +---------------------+----------------+
+                                        |
+                                        v
+                          +---------------------------+
+                          |         PayID URL         |
+                          | https://example.com/alice |
+                          +---------------------------+
 
 ### Step 1: Assemble PayID Discovery URL
   PayID Discovery utilizes the Webfinger [RFC7033][] specification in a
@@ -271,7 +271,7 @@ informative:
 
 ### Step 3: Parse PayID Metadata
   If the PayID Discovery server returns a valid response, the response will
-  contain one or more of the JRDs defined in section 5 of this document.  
+  contain one or more of the JRDs defined in section 5 of this document.
 
   If any of the JRDs contain a 'rel' value that represents a PayID URL
   Template, then that template value MUST be used in the next protocol step.
@@ -363,13 +363,13 @@ The resulting URL is a PayID URL.
     |        PayID URI         |
     |    alice$example.com     |
     +--------------------------+
-                  |              
-                  v              
+                  |
+                  v
     +--------------------------+
     |Manual PayID URL Assembly |
     +--------------------------+
-                  |              
-                  v              
+                  |
+                  v
     +---------------------------+
     |         PayID URL         |
     | https://example.com/alice |
@@ -408,7 +408,7 @@ The resulting URL is a PayID URL.
     {
       "rel": "https://payid.org/ns/payid-uri-template/1.0",
       "template": "https://example.com/{acctpart}"
-    }                
+    }
 
 # Security Considerations
 Various security considerations should be taken into account for PayID
@@ -422,18 +422,18 @@ Discovery.
 As with most services provided on the Internet, it is possible for a domain
 owner to utilize "hosted" WebFinger services. Consult section 7 of
 [RFC7033][] for considerations that could apply to both "manual" and
-"interactive" PayID Discovery when hosted by a third-party.  
+"interactive" PayID Discovery when hosted by a third-party.
 
 ## Cross-Origin Resource Sharing (CORS)
 PayID Discovery resources might not be accessible from a web browser due to
 "Same-Origin" policies. See section 5 of [RFC7033][] for CORS considerations
-that apply to both "manual" and "interactive" PayID Discovery modes.  
+that apply to both "manual" and "interactive" PayID Discovery modes.
 
 ## Access Control
 As with all web resources, access to the PayID Discovery resource could
 require authentication. See section 6 of [RFC7033][] for Access Control
 considerations that could apply to both "manual" and "interactive" PayID
-Discovery modes.  
+Discovery modes.
 
 # IANA Considerations
 

--- a/src/spec/payid-protocol.md
+++ b/src/spec/payid-protocol.md
@@ -67,7 +67,7 @@ This specification is a draft proposal, and is part of the [PayID Protocol
  be sent to <rfcs@payid.org>.
 
 --- abstract
-This specification defines the PayID protocol - an application-layer protocol, which can be used to interact with a PayID-enabled service provider. The primary use case is to discover payment account information along with optional metadata identified by a PayID [PayID-URI][]. The protocol is based on HTTP transfer of PayID protocol messages over a secure transport.   
+This specification defines the PayID protocol - an application-layer protocol, which can be used to interact with a PayID-enabled service provider. The primary use case is to discover payment account information along with optional metadata identified by a PayID [PayID-URI][]. The protocol is based on HTTP transfer of PayID protocol messages over a secure transport.
 
 --- middle
 
@@ -93,20 +93,20 @@ This specification defines the PayID protocol - an application-layer protocol, w
 
 ## Design Goals
 
-   * Extensibility  
+   * Extensibility
 
    Although the primary use case for the payment account(s) information resource returned via the Basic PayID protocol is assumed to be for making payments, the PayID protocol is designed to be easily extensible to facilitate creation and retrieval of other resources about the PayID owner, PayID client and/or PayID server that might be required for making payments.
 
-   * Neutrality: Currency and Network Agnostic  
+   * Neutrality: Currency and Network Agnostic
 
    The PayID protocol is designed to be a fundamentally neutral protocol. The PayID protocol is capable of returning a PayID owner's payment account(s) information for any network that they (or their service) can support. This makes the PayID protocol a network and currency agnostic protocol, capable of enabling payments in BTC, XRP, ERC-20 tokens, Lightning, ILP, or even fiat networks like ACH.
 
-   * Decentralized & Peer-to-Peer  
+   * Decentralized & Peer-to-Peer
 
    Just like email servers, anyone can run their own PayID server or use third-party hosted services. If self-hosted, the PayID protocol introduces no new counterparty risk or changes to a service’s security or privacy model. PayID protocol doesn’t require new, complex, and potentially unreliable peer discovery protocols, instead establishing direct peer-to-peer connections between communicating parties from the start.
    PayID is built on the most successful decentralized network: the web. There is no designated centralized authority, or a risk of a patchwork of different standards in different jurisdictions that make a global solution impossibly complex.
 
-   * Service Sovereignty  
+   * Service Sovereignty
 
    Each service provider that uses PayID for their users maintains full control of its PayID URL space and PayID service, and has the ability to incorporate any policies they choose, including privacy, authentication, and security.  They also have full sovereignty over users on their domain, just like with email. PayID is highly generalized and does not prescribe any particular solution outside of the standardized communication, which makes it compatible with existing compliance and user management tools and philosophies.
 
@@ -133,7 +133,7 @@ This specification defines the PayID protocol - an application-layer protocol, w
 ## Response for application/* + json
   The response body for `application/* + json` is a JSON object with the following name/value pairs.
 
-      {  
+      {
        optional string payId,
        required Address[] addresses,
        optional string memo,
@@ -196,7 +196,7 @@ This specification defines the PayID protocol - an application-layer protocol, w
 ### identity
    The `identity` string may specify any additional identity information about the PayID owner or PayID server.
 
-   The `identity` string is an OPTIONAL field in the response.   
+   The `identity` string is an OPTIONAL field in the response.
 
 ### proofOfControlSignature
   The value of `proofOfControlSignature` field is a JSON object of type `ProofOfControlSignature` with the following name/value pairs.
@@ -328,7 +328,7 @@ This specification defines the PayID protocol - an application-layer protocol, w
   A PayID server MAY redirect the PayID client; if it does, the redirection MUST only be to an `https` URI and the PayID client MUST perform certificate validation again when redirected.
 
 ## Step 3: Parse Payment Account Information Response
-  If the PayID server returns a valid response, the response will contain one or more of the fields defined above.  
+  If the PayID server returns a valid response, the response will contain one or more of the fields defined above.
 
 # Example Use of Basic PayID Protocol
    This section shows sample use of Basic PayID protocol in several hypothetical scenarios.
@@ -356,7 +356,7 @@ This specification defines the PayID protocol - an application-layer protocol, w
        "payId" : "bob$receiver.example.com",
        "addresses" :
        [
-         {  
+         {
            "paymentNetwork" : "xrpl",
            "environment" : "testnet",
            "addressDetailsType" : "CryptoAddressDetails",
@@ -400,7 +400,7 @@ This specification defines the PayID protocol - an application-layer protocol, w
        "payId" : "bob$receiver.example.com",
        "addresses" :
        [
-         {  
+         {
            "paymentNetwork" : "xrpl",
            "environment" : "testnet",
            "addressDetailsType" : "CryptoAddressDetails",
@@ -433,7 +433,7 @@ This specification defines the PayID protocol - an application-layer protocol, w
   The PayID client MAY choose to query for all possible payment addresses corresponding to a PayID URI
 
      GET / HTTP/1.1
-     Accept: application/all+json		  
+     Accept: application/all+json
 
   In this case, the PayID server MAY respond with all payment account(s) information associated with the queried PayID.
 
@@ -469,7 +469,7 @@ This specification defines the PayID protocol - an application-layer protocol, w
   The following are considered out-of-scope:
 
   * Communication between the PayID owner and the wallet or exchange (which acts as PayID server) for PayID URI registration, etc.
-  * Communication between the sender of the transaction and the PayID client to transfer information such as PayID URI and other transaction details, etc.  
+  * Communication between the sender of the transaction and the PayID client to transfer information such as PayID URI and other transaction details, etc.
   * PayID server URL discovery by the PayID client. Implementations using PayID-Discovery [PAYID-DISCOVERY][] MUST consider the security considerations in the corresponding document.
   * PayID server URL resolution by the PayID client. Implementations using DNS, DNSSEC, DoH, DoT, etc. MUST consider the security considerations of the corresponding documents.
 
@@ -494,16 +494,16 @@ This specification defines the PayID protocol - an application-layer protocol, w
   The PayID servers are recommended to follow general best network configuration practices to defend against such attacks [RFC4732][].
 
 ## Information Integrity
-  The HTTPS connection provides transport security for the interaction between PayID client and server but does not provide the response integrity of the data provided by PayID server. A PayID client has no way of knowing if data provided in the payment account information resource has been manipulated at the PayID server, either due to malicious behavior on the part of the PayID server administrator or as a result of being compromised by an attacker. As with any information service available on the Internet, PayID clients should be wary of the information received from untrusted sources.  
+  The HTTPS connection provides transport security for the interaction between PayID client and server but does not provide the response integrity of the data provided by PayID server. A PayID client has no way of knowing if data provided in the payment account information resource has been manipulated at the PayID server, either due to malicious behavior on the part of the PayID server administrator or as a result of being compromised by an attacker. As with any information service available on the Internet, PayID clients should be wary of the information received from untrusted sources.
 
 # Privacy Considerations
-  The PayID client and server should be aware that placing information on the Internet means that any one can access that information. While PayID protocol is an extremely useful tool to discovering payment account(s) information corresponding to a human-rememberable PayID URI, PayID owners should also understand the associated privacy risks. The easy access to payment account information via PayID protocol was a design goal of the protocol, not a limitation.  
+  The PayID client and server should be aware that placing information on the Internet means that any one can access that information. While PayID protocol is an extremely useful tool to discovering payment account(s) information corresponding to a human-rememberable PayID URI, PayID owners should also understand the associated privacy risks. The easy access to payment account information via PayID protocol was a design goal of the protocol, not a limitation.
 
 ## Access Control
-  PayID protocol MUST NOT be used to provide payment account(s) information corresponding to a PayID URI unless providing that data via PayID protocol by the relevant PayID server was explicitly authorized by the PayID owner. If a PayID owner wishes to limit access to information, PayID servers MAY provide an interface by which PayID owners can select which information is exposed through the PayID server interface. For example, PayID servers MAY allow PayID owners to mark certain data as `public` and then utilize that marking as a means of determining what information to expose via PayID protocol. The PayID servers MAY also allow PayID owners to provide a whitelist of users who are authorized to access the specific information. In such a case, the PayID server MUST authenticate the PayID client.  
+  PayID protocol MUST NOT be used to provide payment account(s) information corresponding to a PayID URI unless providing that data via PayID protocol by the relevant PayID server was explicitly authorized by the PayID owner. If a PayID owner wishes to limit access to information, PayID servers MAY provide an interface by which PayID owners can select which information is exposed through the PayID server interface. For example, PayID servers MAY allow PayID owners to mark certain data as `public` and then utilize that marking as a means of determining what information to expose via PayID protocol. The PayID servers MAY also allow PayID owners to provide a whitelist of users who are authorized to access the specific information. In such a case, the PayID server MUST authenticate the PayID client.
 
 ## Payment Address Rotation
-  The power of PayID protocol comes from providing a single place where others can find payment account(s) information corresponding to a PayID URI, but PayID owners should be aware of how easily payment account information that one might publish can be used in unintended ways. As one example, one might query a PayID server only to see if a given PayID URI is valid and if so, get the list of associated payment account information. If the PayID server uses the same payment address each time, it becomes easy for a third-party to track one's entire payment history. The PayID server MUST follow the best practice of payment address rotation for every query to mitigate this privacy concern.  
+  The power of PayID protocol comes from providing a single place where others can find payment account(s) information corresponding to a PayID URI, but PayID owners should be aware of how easily payment account information that one might publish can be used in unintended ways. As one example, one might query a PayID server only to see if a given PayID URI is valid and if so, get the list of associated payment account information. If the PayID server uses the same payment address each time, it becomes easy for a third-party to track one's entire payment history. The PayID server MUST follow the best practice of payment address rotation for every query to mitigate this privacy concern.
 
 ## On the Wire
   PayID protocol over HTTPS encrypts the traffic and requires mutual authentication of the PayID client and the PayID server. This mitigates both passive surveillance [RFC7258][] and the active attacks that attempt to divert PayID protocol queries to rogue servers.
@@ -555,7 +555,7 @@ This specification defines the PayID protocol - an application-layer protocol, w
 | application | xrpl-testnet+json        |
 | application | xrpl-devnet+json         |
 | application | ach+json                 |
-| application | interledger-mainnet+json |               
+| application | interledger-mainnet+json |
 | application | interledger-testnet+json |
 | application | payid+json               |
 

--- a/src/spec/payid-uri.md
+++ b/src/spec/payid-uri.md
@@ -10,7 +10,7 @@ smart_quotes: off
 
 area: security
 author:
-      
+
   -
     ins: D. Fuelling
     name: David Fuelling
@@ -20,7 +20,7 @@ author:
     region: CA
     code: 94104
     country: US
-      
+
 normative:
     RFC2119:
     RFC3629:
@@ -29,13 +29,13 @@ normative:
     RFC5890:
     RFC5892:
     RFC8264:
-    PAYID-DISCOVERY: 
+    PAYID-DISCOVERY:
       title: "The PayID Discovery Protocol"
       target: https://tbd.example.com/
       author:
         ins: D. Fuelling
         fullname: David Fuelling
-    PAYID-PROTOCOL: 
+    PAYID-PROTOCOL:
       title: "PayID Protocol"
       target: https://tbd.example.com/
       author:
@@ -43,7 +43,7 @@ normative:
            fullname: Aanchal Malhotra
          - ins: D. Schwartz
            fullname: David Schwartz
-    VERIFIABLE-PAYID: 
+    VERIFIABLE-PAYID:
        title: "Verifiable PayID Protocol"
        target: https://tbd.example.com/
        author:
@@ -57,9 +57,9 @@ normative:
       author:
         surname: The Unicode Consortium
         fullname: The Unicode Consortium
- 
+
 informative:
-    RFC0020: 
+    RFC0020:
     RFC5988:
     RFC6068:
     RFC7033:
@@ -67,126 +67,126 @@ informative:
     RFC7595:
 
 --- note_Feedback
-  This specification is a draft proposal, and is part of the 
-  [PayID Protocol](https://payid.org/) initiative. Feedback related to this 
-  document should be sent in the form of a Github issue at: 
+  This specification is a draft proposal, and is part of the
+  [PayID Protocol](https://payid.org/) initiative. Feedback related to this
+  document should be sent in the form of a Github issue at:
   https://github.com/payid-org/rfcs/issues.
 
 --- abstract
-  This specification defines the 'payid' Uniform Resource Identifier (URI) 
+  This specification defines the 'payid' Uniform Resource Identifier (URI)
   scheme as a way to identify a payment account at a service provider.
-   
+
 --- middle
 
 # Introduction
    Various Uniform Resource Identifier (URI) schemes can be used to
-   identify a user account at a service provider. However, no standard 
+   identify a user account at a service provider. However, no standard
    identifier exists to identify a user's _payment_ account at a service
    provider.
-   
-   While popular URIs could be re-used as payment account identifiers, 
+
+   While popular URIs could be re-used as payment account identifiers,
    these identifiers are insufficient because they are typically recognized
    as supporting functionality unique to those schemes. For example, the
-   'mailto' scheme [RFC6068][] is broadly deployed for messaging. Re-using 
+   'mailto' scheme [RFC6068][] is broadly deployed for messaging. Re-using
    this identifier for payments would likely cause confusion because one
    desirable quality of a payment account identifier is that it expressly
    does not support messaging, in order to avoid spam and/or other security
    concerns such as phishing attacks.
-   
+
    Deploying payment protocols on top of identifiers that are commonly
    employed for other use-cases would likely be a mis-use of those
    identifiers, and could also cause confusion for end-users, among other
    problems.
-   
+
    Instead, the 'payid' scheme defines an identifier that is intended to
    identify accounts for payment use-cases only.
- 
+
 # Terminology
    The key words "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT",
    "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and
    "OPTIONAL" in this document are to be interpreted as described in
    [RFC2119][].
- 
+
 # Definition
    The syntax of the 'payid' URI scheme is defined in Section 7 of this
    document.
-   
-   A 'payid' URI identifies a payment account hosted at a service provider, 
+
+   A 'payid' URI identifies a payment account hosted at a service provider,
    and is designed for payment account identification rather than
-   interaction, as discussed in section 1.2.2 of [RFC3986]. 
-     
-   A 'payid' URI is constructed by taking a user's payment account identifier 
-   at a service provider and using that value as the 'acctpart'. The 'host' 
+   interaction, as discussed in section 1.2.2 of [RFC3986].
+
+   A 'payid' URI is constructed by taking a user's payment account identifier
+   at a service provider and using that value as the 'acctpart'. The 'host'
    portion is then set to the DNS domain name of the service provider that
    provides the 'payid'.
-      
-   To compare two 'payid' URIs, case normalization and percent-encoding 
+
+   To compare two 'payid' URIs, case normalization and percent-encoding
    normalization (as specified in sections 6.2.2.1 and 6.2.2.2 of
    [RFC3986]) MUST be employed before performing any comparison.
-   
+
    In addition, a 'payid' is case-insensitive and therefore should be
-   normalized to lowercase.  For example, the URI 
-   "PAYID:aLICE$www.EXAMPLE.com" is equivalent to 
+   normalized to lowercase.  For example, the URI
+   "PAYID:aLICE$www.EXAMPLE.com" is equivalent to
    "payid:alice$www.example.com".
-   
+
    Note that both the 'acctpart' and 'host' components of a 'payid' may
-   contain one or more dollar-sign characters. However, because a 'host' 
+   contain one or more dollar-sign characters. However, because a 'host'
    SHOULD also be a valid DNS domain, that portion of a 'payid' will
    generally not include a dollar-sign. Therefore, applications SHOULD
-   always search for the last dollar-sign when attempting to parse a 'payid' 
+   always search for the last dollar-sign when attempting to parse a 'payid'
    URI into its two component parts.
 
-# Examples                                                              
+# Examples
    As an example, a user with an account name of "apollo" at a wallet
-   service "wallet.example.com" can be identified by a URI using the 'payid' 
-   scheme via the following construction: 
-   
+   service "wallet.example.com" can be identified by a URI using the 'payid'
+   scheme via the following construction:
+
      'payid:apollo$wallet.example.com'
 
-   One possible PayID scenario is for an account to be registered with a 
-   payment service provider using an identifier that is associated with some 
-   other service provider. For example, a user with the email address 
+   One possible PayID scenario is for an account to be registered with a
+   payment service provider using an identifier that is associated with some
+   other service provider. For example, a user with the email address
    "alice@example.net" might register with a wallet website whose domain
    name is "wallet.example.com". In order to facilitate payments to/from
-   Alice, the wallet service provider might offer Alice a PayID using Alice's 
+   Alice, the wallet service provider might offer Alice a PayID using Alice's
    email address (though using an email address as a PayID is not
    recommended).  In order to use Alice's email address as the 'acctpart' of
-   the 'payid' URI, no percent-encoding is necessary because the 'acctpart' 
-   portion of a PayID allows for at-signs. Thus, the provisioned 'payid' URI 
+   the 'payid' URI, no percent-encoding is necessary because the 'acctpart'
+   portion of a PayID allows for at-signs. Thus, the provisioned 'payid' URI
    for Alice would be "payid:alice@example.net$shoppingsite.example".
-   
+
    Another possible scenario is where a payment service provider (e.g., a
    digital wallet) provides its users with PayIDs that are associated with
    the PayIDs of another service provider. For example, a user with the
-   PayID "alice$bank.example.net" might register with a wallet website whose 
+   PayID "alice$bank.example.net" might register with a wallet website whose
    domain name is "wallet.example.net". In order to use the bank's PayID
-   as the acctpart of the wallet's 'payid' URI, no percent-encoding is 
-   necessary because the 'acctpart' portion of a PayID allows for 
-   dollar-signs. Therefore, the resulting 'payid' URI would be 
+   as the acctpart of the wallet's 'payid' URI, no percent-encoding is
+   necessary because the 'acctpart' portion of a PayID allows for
+   dollar-signs. Therefore, the resulting 'payid' URI would be
    "payid:alice$bank.example$wallet.example".
-      
+
    The following example URIs illustrate several variations of PayIDs and
    their common syntax components:
-   
+
          payid:alice$example.net
-         
+
          payid:john.doe$example.net
-         
+
          payid:jane-doe$example.net
-         
+
 # Security Concerns
    The 'payid' URI scheme defined in this document does not directly enable
    interaction with a user's payment account and therefore does not present
    any direct security concerns.
-   
+
    However, a 'payid' URI indicates existence of a payment account, so
-   care should be taken to properly secure any payment account interactions 
-   allowed by a service provider. 
-   
-   In addition, service providers and users should consider whether an 
+   care should be taken to properly secure any payment account interactions
+   allowed by a service provider.
+
+   In addition, service providers and users should consider whether an
    attacker might be able to derive or infer other identifiers correlating
-   to the user of any particular PayID. For example, replacing the `$` 
-   character in a PayID with an `@` sign SHOULD NOT yield a 'mailto' URI, 
+   to the user of any particular PayID. For example, replacing the `$`
+   character in a PayID with an `@` sign SHOULD NOT yield a 'mailto' URI,
    when possible. In addition, care should be taken when the 'acctpart' of
    a PayID corresponds to a user's email address (in part or in whole) as this
    might allow an attacker to execute phishing attacks or send spam messages.
@@ -195,7 +195,7 @@ informative:
    disallow percent-encoded characters or sequences that would result in
    "space", "null", "control", or other characters that are otherwise
    forbidden.
-         
+
 # Internationalization Concerns
    As specified in [RFC3986], the 'payid' URI scheme allows any character
    from the Unicode repertoire [Unicode] encoded as UTF-8 [RFC3629] and
@@ -211,7 +211,7 @@ informative:
 
    * Internationalized domain name (IDN) labels are encoded as A-labels
     [RFC5890].
-    
+
 # IANA Considerations
    In accordance with [RFC7595], this section provides the information
    needed to register the 'payid' URI scheme.
@@ -221,7 +221,7 @@ informative:
    **Status**: permanent
 
    **URI Scheme Syntax**:  The 'payid' URI syntax is defined here in Augmented
-   Backus-Naur Form (ABNF) per [RFC5234], borrowing the 'host' and 'path' 
+   Backus-Naur Form (ABNF) per [RFC5234], borrowing the 'host' and 'path'
    rules from [RFC3986]:
 
       payidURI   = "payid" ":" acctpart "$" host
@@ -231,16 +231,16 @@ informative:
    percent-encoded in a 'payid' URI. See "Encoding Considerations" below for
    more details.
 
-   **URI Scheme Semantics**:  The 'payid' URI scheme identifies payment 
+   **URI Scheme Semantics**:  The 'payid' URI scheme identifies payment
       accounts hosted at payment service providers.  It is used only for
       identification, not interaction.
 
    **Encoding Considerations**:  See Section 6 of this document.
 
    **Applications/Protocols That Use This URI Scheme Name**: The following
-    protocols utilize this URI scheme: 
-    
-      - [PAYID-DISCOVERY][], 
+    protocols utilize this URI scheme:
+
+      - [PAYID-DISCOVERY][],
       - [PAYID-PROTOCOL][],
       - [VERIFIABLE-PAYID][].
 
@@ -253,12 +253,12 @@ informative:
    **Author/Change Controller**:  TBD.
 
    **References**:  None.
-   
+
 # Acknowledgements
-  This document was adapted from and heavily influenced by [RFC7565][], 
+  This document was adapted from and heavily influenced by [RFC7565][],
   modifying it (in some cases only slightly) for a payments use-case. The
   author would like to acknowledge the contributions of everyone who worked
-  on that and related specifications. 
-  
+  on that and related specifications.
+
   In addition, the author would like to acknowledge everyone who provided
   feedback and use-cases for this derivative specification.

--- a/src/spec/verifiable-payid-protocol.md
+++ b/src/spec/verifiable-payid-protocol.md
@@ -184,11 +184,11 @@ This specification defines the Verifiable PayID protocol - an extension to [PAYI
 #### publicKeyType
    The value of `publicKeyType` is the Public Key Infrastructure (PKI)/identity system being used to identify the signing endpoint. e.g. `X509+SHA512` means an X.509 certificate as described in [RFC5280][] and SHA512 hash algorithm used to hash the contents of `message` for signing. This field defaults to empty string. We define the following `publicKeyType` values. One can register more in future.
 
-   | publicKeyType   | Description                  
+   | publicKeyType   | Description
    |-----------------|-----------------------------------------------------
-   | X509+SHA512     | A X.509 certificate [RFC5280][]        
-   | pgp+SHA512      | An OpenPGP certificate        
-   | ecdsa+SHA256    | A secp256k1 ECDSA public key [RFC6979][] [RFC8422][]        
+   | X509+SHA512     | A X.509 certificate [RFC5280][]
+   | pgp+SHA512      | An OpenPGP certificate
+   | ecdsa+SHA256    | A secp256k1 ECDSA public key [RFC6979][] [RFC8422][]
 
 #### publicKeyData
    The value of `publicKeyData` is the PKI-system/identity data used to identify the signing endpoint who creates digital signatures over the hash of the contents of the `message`. e.g. in the case of X.509 certificates, it may contain one or more X.509 certificates as a list upto the root trust certificate. Defaults to empty.
@@ -285,11 +285,11 @@ This signed payment account(s) information message is then securely transferred 
 ### identity field in payment account(s) information message
  The following table enumerates the possible ways to share the public key of PayID owner using `identity` field.
 
- | identity                                   | Description               
+ | identity                                   | Description
 |--------------------------------------------|---------------------------------
-| Global Identifier (GiD) [Gid][]                   | digital identifier              
-| Human Universally Unique Identifier (Human UUID) [HUUID][] | digital identifier              
-| Digital Identifier (DID) [DID][]                  | digital identifier              
+| Global Identifier (GiD) [Gid][]                   | digital identifier
+| Human Universally Unique Identifier (Human UUID) [HUUID][] | digital identifier
+| Digital Identifier (DID) [DID][]                  | digital identifier
 | Certificate                                | attested certificate that associates digital identifier to PayID and public key
 | URL                                        | URL for secure retrieval of public key of the PayID owner
 | Public key                                 | out-of-band pre-shared public key between PayID client and PayID owner
@@ -356,7 +356,7 @@ This signed payment account(s) information message is then securely transferred 
        "payId" : "bob$receiver.example.com",
        "addresses" :
        [
-         {  
+         {
            "paymentNetwork" : "xrpl",
            "environment" : "testnet",
            "addressDetailsType" : "CryptoAddressDetails",
@@ -402,7 +402,7 @@ This signed payment account(s) information message is then securely transferred 
        "payId" : "bob$receiver.example.com",
        "addresses" :
        [
-         {  
+         {
            "paymentNetwork" : "xrpl",
            "environment" : "testnet",
            "addressDetailsType" : "CryptoAddressDetails",
@@ -424,7 +424,7 @@ This signed payment account(s) information message is then securely transferred 
 # Security Considerations
   This security considerations section only considers verifiable PayID clients and servers bound to implementations as defined in this document.
 
-  The security guarantees mentioned in [PAYID-PROTOCOL][] applies to the Verifiable PayID protocol. In this section, we discuss a security model for the Verifiable PayID protocol.  
+  The security guarantees mentioned in [PAYID-PROTOCOL][] applies to the Verifiable PayID protocol. In this section, we discuss a security model for the Verifiable PayID protocol.
 
 ## Fully-Malicious Adversary Model for PayID Client Wallet and Custodial Wallets and Exchanges as PayID Servers
 


### PR DESCRIPTION
## High Level Overview of Change

Remove trailing whitespace from RFCs.

No functional changes except the expiration dates changing as a consequence of re-generating the specs.

### Context of Change

VSCode automatically removes trailing whitespace on file saves for me, so it's difficult for me to work on the RFCs and know what changes are real and which are whitespace.

### Type of Change

<!--
Please check relevant options, delete irrelevant ones.
-->

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [x] Refactor (non-breaking change that only restructures code)
- [ ] Tests (You added tests for code that already exists, or your new feature included in this PR)
- [ ] Documentation Updates
- [ ] Release

<!--
## Future Tasks
For future tasks related to PR.
-->
